### PR TITLE
Update pubspec.yaml for Dart 2

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,4 +15,4 @@ dependencies:
     sdk: flutter
 
 environment:
-    sdk: ">=1.8.0 <2.0.0"
+    sdk: ">=1.8.0 <3.0.0"


### PR DESCRIPTION
This will set the upper constraint of Dart SDK to <3.0.0 for latest Flutter compatibility.