### PR TITLE
fixes the crash while building the APK

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,7 +27,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 25
+    compileSdkVersion 28
 
     defaultConfig {
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"


### PR DESCRIPTION
Android Resources of 25 compile SDK does not match with that of 28

```
1: Task failed with an exception.                                       
-----------                                                             
* What went wrong:                                                      
Execution failed for task ':qrcode_reader:verifyReleaseResources'.      
> A failure occurred while executing com.android.build.gradle.internal.tasks.Workers$ActionFacade
   > Android resource linking failed                                    
     /home/harsh/.gradle/caches/transforms-2/files-2.1/79a43a903ecb6dc82204ee669e724ddc/core-1.0.0/res/values/values.xml:57:5-88:25: AAPT: error: resource android:attr/fontStyle not found.
                                                                        
     /home/harsh/.gradle/caches/transforms-2/files-2.1/79a43a903ecb6dc82204ee669e724ddc/core-1.0.0/res/values/values.xml:57:5-88:25: AAPT: error: resource android:attr/font not found.
                                                                        
     /home/harsh/.gradle/caches/transforms-2/files-2.1/79a43a903ecb6dc82204ee669e724ddc/core-1.0.0/res/values/values.xml:57:5-88:25: AAPT: error: resource android:attr/fontWeight not found.
                                                                        
     /home/harsh/.gradle/caches/transforms-2/files-2.1/79a43a903ecb6dc82204ee669e724ddc/core-1.0.0/res/values/values.xml:57:5-88:25: AAPT: error: resource android:attr/fontVariationSettings not found.
                                                                        
     /home/harsh/.gradle/caches/transforms-2/files-2.1/79a43a903ecb6dc82204ee669e724ddc/core-1.0.0/res/values/values.xml:57:5-88:25: AAPT: error: resource android:attr/ttcIndex not found.

```