### PR TITLE
Changed reference to FlutterActivity to just Activity

### DIFF
--- a/android/src/main/java/com/matheusvillela/flutter/plugins/qrcodereader/QRCodeReaderPlugin.java
+++ b/android/src/main/java/com/matheusvillela/flutter/plugins/qrcodereader/QRCodeReaderPlugin.java
@@ -31,7 +31,6 @@ import android.os.Process;
 
 import java.util.Map;
 
-import io.flutter.app.FlutterActivity;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
@@ -46,19 +45,19 @@ public class QRCodeReaderPlugin implements MethodCallHandler, ActivityResultList
     private static final int REQUEST_CODE_CAMERA_PERMISSION = 3777;
     //    private static QRCodeReaderPlugin instance;
 
-    private FlutterActivity activity;
+    private Activity activity;
     private Result pendingResult;
     private Map<String, Object> arguments;
     private boolean executeAfterPermissionGranted;
 
-    public QRCodeReaderPlugin(FlutterActivity activity) {
+    public QRCodeReaderPlugin(Activity activity) {
         this.activity = activity;
     }
 
     public static void registerWith(PluginRegistry.Registrar registrar) {
 	//        if (instance == null) {
             final MethodChannel channel = new MethodChannel(registrar.messenger(), CHANNEL);
-            final QRCodeReaderPlugin instance = new QRCodeReaderPlugin((FlutterActivity) registrar.activity());
+            final QRCodeReaderPlugin instance = new QRCodeReaderPlugin(registrar.activity());
             registrar.addActivityResultListener(instance);
             registrar.addRequestPermissionsResultListener(instance);
             channel.setMethodCallHandler(instance);


### PR DESCRIPTION
Some plugins (e.g. [local_auth](https://pub.dev/packages/local_auth)) require the user to change their MainActivity from a FlutterActivity to a FlutterFragmentActivity. 

Guidlines on the [Flutter plugin documentation](https://api.flutter.dev/javadoc/io/flutter/plugin/common/PluginRegistry.Registrar.html#activity--) suggest 

> Plugin authors should not assume the type returned by this method is any specific subclass of Activity (such as FlutterActivity or FlutterFragmentActivity), as applications are free to use any activity subclass.

I see no reason why the application needs a FlutterActivity specifically, and so I have change this to expect just a regular Activity. I have tested this in my own application that uses a FlutterFragmentActivity for local_auth, and have seen no problems.